### PR TITLE
Scripts to run the interpreter without the cargo statement and add random function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 rustyline = "14.0.0"
+rand = "0.8.5"

--- a/scripts/filipec
+++ b/scripts/filipec
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    cargo run
+else
+    cargo run run "$@" 2> >(grep -v "Finished dev" >&2) | grep -v "Running"
+fi

--- a/scripts/filipec
+++ b/scripts/filipec
@@ -3,5 +3,5 @@
 if [ $# -eq 0 ]; then
     cargo run
 else
-    cargo run run "$@" 2> >(grep -v "Finished dev" >&2) | grep -v "Running"
+    cargo run run "$@"
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+script_path="$(pwd)/scripts/filipec"
+
+shell=$(ps -p $PPID -o command=)
+
+if [ "$shell" = "bash" ]; then
+    if [ -f ~/.bashrc ]; then
+        echo "Adding alias to ~/.bashrc..."
+        echo "alias filipec=\"$script_path\"" >> ~/.bashrc
+        echo "Alias 'filipec' added to ~/.bashrc."
+        source ~/.bashrc
+    else
+        echo "No ~/.bashrc file found. The alias 'filipec' could not be added."
+        exit 1
+    fi
+elif [ "$shell" = "zsh" ]; then
+    if [ -f ~/.zshrc ]; then
+        echo "Adding alias to ~/.zshrc..."
+        echo "alias filipec=\"$script_path\"" >> ~/.zshrc
+        echo "Alias 'filipec' added to ~/.zshrc."
+        source ~/.zshrc
+    else
+        echo "No ~/.zshrc file found. The alias 'filipec' could not be added."
+        exit 1
+    fi
+else
+    echo "Unrecognized shell: $shell. The alias 'filipec' could not be added."
+    exit 1
+fi

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -70,16 +70,6 @@ impl Context {
         self.store.contains_key(name)
     }
 
-    pub fn has_deep(&self, name: &str) -> bool {
-        if self.store.contains_key(name) {
-            return true;
-        }
-        match self.parent {
-            Some(ref p) => p.borrow().has_deep(name),
-            None => false,
-        }
-    }
-
     pub fn resolve(&self, name: &str) -> Option<ObjectInfo> {
         if self.store.contains_key(name) {
             let obj = self.store.get(name).unwrap();

--- a/src/runtime/runtime_error.rs
+++ b/src/runtime/runtime_error.rs
@@ -5,6 +5,7 @@ pub enum ErrorKind {
     NameError,
     TypeError,
     ArgumentError,
+    ValueError,
 }
 
 #[derive(Clone)]
@@ -46,6 +47,7 @@ impl RuntimeErrorHandler {
             msg,
         });
     }
+
 }
 
 impl fmt::Display for RuntimeError {
@@ -60,6 +62,7 @@ impl fmt::Display for ErrorKind {
             Self::NameError => write!(f, "[Name error]"),
             Self::TypeError => write!(f, "[Type Error]"),
             Self::ArgumentError => write!(f, "[Argument Error]"),
+            Self::ValueError => write!(f, "[Value Error]"),
         }
     }
 }


### PR DESCRIPTION
This pull request introduces scripts to facilitate running the interpreter without the need for the "cargo" statement. Also, it adds the "random" function to the interpreter.

The scripts included in this pull request allow users to execute the interpreter directly without invoking "cargo run".

The "random" function has been implemented to provide functionality for generating random values within specified ranges or without arguments.

Thank you for reviewing this pull request.